### PR TITLE
feat: Fix build on FreeBSD by updating jwt-simple to use "pure-rust"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ http-body = "1.0.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0", features = ["full"] }
 hyper-util = { version = "0.1.14", features = ["tokio"] }
-jwt-simple = "0.12.12"
 matchit = "0.8.6"
 mime = "0.3.17"
 mime_guess = "2.0.5"
@@ -60,6 +59,12 @@ urlencoding = "2.1.3"
 uuid = { version = "1.17.0", optional = true, features = ["v4"] }
 webpki-roots = { version = "1.0.1", optional = true }
 zstd = { version = "0.13.3", optional = true }
+
+[target.'cfg(target_os = "freebsd")'.dependencies]
+jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
+
+[target.'cfg(not(target_os = "freebsd"))'.dependencies]
+jwt-simple = { version = "0.12.12" }
 
 [features]
 async-graphql = ["dep:async-graphql"]


### PR DESCRIPTION
This builds BoringSSL using the pure rust feature, which fixes the build on FreeBSD.

Requires building tako with `--features "pure-rust"` to enable.

Fixes #14 